### PR TITLE
Ego state: pose uncertainty, quality flags, and implicit camera world poses

### DIFF
--- a/src/py123d/api/scene/arrow/modalities/arrow_camera.py
+++ b/src/py123d/api/scene/arrow/modalities/arrow_camera.py
@@ -1,12 +1,15 @@
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional, Tuple, Union
 
 import cv2
 import numpy as np
+import numpy.typing as npt
 import pyarrow as pa
 
 from py123d.api.scene.arrow.modalities.arrow_base import ArrowBaseModalityReader, ArrowBaseModalityWriter
 from py123d.api.scene.arrow.modalities.utils import all_columns_in_schema
+from py123d.api.utils.arrow_helper import get_lru_cached_arrow_table
 from py123d.api.utils.arrow_metadata_utils import add_metadata_to_arrow_schema
 from py123d.common.io.camera.jpeg_camera_io import (
     decode_image_from_jpeg_binary,
@@ -26,11 +29,18 @@ from py123d.common.io.camera.png_camera_io import (
     load_png_binary_from_png_file,
 )
 from py123d.common.runtime import get_dataset_paths
-from py123d.datatypes.modalities.base_modality import BaseModality, BaseModalityMetadata
+from py123d.datatypes.modalities.base_modality import (
+    BaseModality,
+    BaseModalityMetadata,
+    ModalityType,
+    get_modality_key,
+)
 from py123d.datatypes.sensors.base_camera import BaseCameraMetadata, Camera, CameraChannelType
 from py123d.datatypes.time.timestamp import Timestamp
 from py123d.geometry.geometry_index import PoseSE3Index
 from py123d.geometry.pose import PoseSE3
+from py123d.geometry.transform.transform_se3 import rel_to_abs_se3
+from py123d.geometry.utils.rotation_utils import slerp_quaternion_arrays
 from py123d.parser.base_dataset_parser import ParsedCamera
 
 # ------------------------------------------------------------------------------------------------------------------
@@ -122,6 +132,8 @@ class ArrowCameraWriter(ArrowBaseModalityWriter):
                 f"{self._metadata.modality_key}.timestamp_us": [modality.timestamp.time_us],
                 f"{self._metadata.modality_key}.data": [data],
                 f"{self._metadata.modality_key}.camera_to_global_se3": [modality.camera_to_global_se3],
+                # None where a dataset stores the pose implicitly, to be composed on read from
+                # ego_state_se3 and the camera extrinsic (see _camera_to_global_from_ego).
                 f"{self._metadata.modality_key}.exposure_factor": [modality.exposure_factor],
             }
         )
@@ -277,6 +289,14 @@ class ArrowCameraReader(ArrowBaseModalityReader):
         full_column_name = f"{metadata.modality_key}.{column}"
         if full_column_name in table.column_names:
             column_at_iteration = table[full_column_name][index].as_py()
+        if column == "camera_to_global_se3" and column_at_iteration is None:
+            # Stored implicitly; see _camera_to_global_from_ego. Returned in the same shape the
+            # column would have had, so a caller that asked for the raw value still gets one.
+            timestamp_column = f"{metadata.modality_key}.timestamp_us"
+            timestamp_us = table[timestamp_column][index].as_py() if timestamp_column in table.column_names else None
+            assert isinstance(metadata, BaseCameraMetadata)
+            pose = _camera_to_global_from_ego(log_dir, metadata, timestamp_us)
+            return pose if (deserialize and pose is not None) else (None if pose is None else pose.tolist())
         if deserialize and column_at_iteration is not None:
             if column == "data":
                 column_at_iteration = _deserialize_data_column(
@@ -292,6 +312,90 @@ class ArrowCameraReader(ArrowBaseModalityReader):
             elif column == "timestamp_us":
                 column_at_iteration = Timestamp.from_us(column_at_iteration)
         return column_at_iteration
+
+
+# ------------------------------------------------------------------------------------------------------------------
+# Camera pose from the ego trajectory
+# ------------------------------------------------------------------------------------------------------------------
+
+# ``camera_to_global_se3`` is ego_pose composed with the camera's own extrinsic, so it is the one
+# per-frame field that a change to the ego trajectory invalidates. A dataset may therefore leave
+# it null and have it composed here instead, which turns re-estimating a trajectory from a
+# rewrite of every camera table into a rewrite of ``ego_state_se3.arrow`` alone -- on the Kesai
+# logs, 7 MB rather than 38 GB. Nothing else changes: lidar and radar points are stored in the
+# IMU frame and are unaffected by the ego pose, and a log that carries the column keeps using it,
+# so every dataset written before this reads back exactly as it did.
+
+
+def _ego_state_key() -> str:
+    """The modality key the ego trajectory is stored under, from the enum rather than a literal."""
+    return get_modality_key(ModalityType.EGO_STATE_SE3)
+
+
+@lru_cache(maxsize=8)
+def _ego_trajectory(log_dir_str: str) -> Optional[Tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]]:
+    """The log's ego poses as arrays, cached per log directory.
+
+    :param log_dir_str: The log directory, as a string so it can be a cache key.
+    :return: Tuple of (timestamps in microseconds, (N, 7) poses), or None if the log has no ego states.
+    """
+    path = Path(log_dir_str) / f"{_ego_state_key()}.arrow"
+    if not path.exists():
+        return None
+    table = get_lru_cached_arrow_table(path)
+    timestamp_column = f"{_ego_state_key()}.timestamp_us"
+    pose_column = f"{_ego_state_key()}.imu_se3"
+    if timestamp_column not in table.column_names or pose_column not in table.column_names:
+        return None
+    timestamps = table[timestamp_column].to_numpy().astype(np.int64)
+    poses = np.asarray(table[pose_column].to_pylist(), dtype=np.float64)
+    if not len(timestamps) or poses.shape[-1] != len(PoseSE3Index):
+        return None
+    return timestamps, poses
+
+
+def _ego_pose_at(timestamps_us: npt.NDArray[np.int64], poses: npt.NDArray[np.float64], timestamp_us: int) -> PoseSE3:
+    """The ego pose at an arbitrary time, interpolated and clamped to the trajectory's range.
+
+    Interpolated rather than snapped: the ego states are 100 Hz and a camera frame falls between
+    them, so taking the nearest would displace the pose by up to 5 ms of travel -- 15 cm at
+    30 m/s, which is the same order as the trajectory's own accuracy.
+    """
+    if len(timestamps_us) == 1:
+        return PoseSE3.from_list(poses[0].tolist())
+    clamped = int(np.clip(timestamp_us, timestamps_us[0], timestamps_us[-1]))
+    upper = int(np.clip(np.searchsorted(timestamps_us, clamped, side="right"), 1, len(timestamps_us) - 1))
+    lower = upper - 1
+    span = float(timestamps_us[upper] - timestamps_us[lower])
+    ratio = 0.0 if span <= 0.0 else (clamped - timestamps_us[lower]) / span
+
+    interpolated = np.empty(len(PoseSE3Index), dtype=np.float64)
+    interpolated[PoseSE3Index.XYZ] = (
+        poses[lower, PoseSE3Index.XYZ] + (poses[upper, PoseSE3Index.XYZ] - poses[lower, PoseSE3Index.XYZ]) * ratio
+    )
+    interpolated[PoseSE3Index.QUATERNION] = slerp_quaternion_arrays(
+        poses[lower, PoseSE3Index.QUATERNION], poses[upper, PoseSE3Index.QUATERNION], np.array(ratio)
+    )
+    return PoseSE3.from_list(interpolated.tolist())
+
+
+def _camera_to_global_from_ego(
+    log_dir: Optional[Path], metadata: BaseCameraMetadata, timestamp_us: Optional[int]
+) -> Optional[PoseSE3]:
+    """Compose the camera's world pose from the log's ego trajectory and the camera extrinsic.
+
+    :param log_dir: The log directory; without it the trajectory cannot be found.
+    :param metadata: The camera metadata, carrying ``camera_to_imu_se3``.
+    :param timestamp_us: The frame time to place the camera at.
+    :return: The camera-to-global pose, or None when the log carries no ego trajectory.
+    """
+    if log_dir is None or timestamp_us is None:
+        return None
+    trajectory = _ego_trajectory(str(log_dir))
+    if trajectory is None:
+        return None
+    timestamps_us, poses = trajectory
+    return rel_to_abs_se3(origin=_ego_pose_at(timestamps_us, poses, timestamp_us), pose_se3=metadata.camera_to_imu_se3)
 
 
 # ------------------------------------------------------------------------------------------------------------------
@@ -329,8 +433,17 @@ def _deserialize_camera(
         else None
     )
 
-    if table_data is None or camera_to_global_se3_data is None:
+    if table_data is None:
         return None
+    # A null pose means the dataset stores it implicitly: compose it from the ego trajectory and
+    # the camera's own extrinsic. A dataset that wrote the column keeps its stored value, so
+    # every log written before this reads back byte for byte as it did.
+    if camera_to_global_se3_data is None:
+        camera_to_global_se3 = _camera_to_global_from_ego(log_dir, camera_metadata, timestamp_data)
+        if camera_to_global_se3 is None:
+            return None
+    else:
+        camera_to_global_se3 = PoseSE3.from_list(camera_to_global_se3_data)
     image = _deserialize_data_column(
         data=table_data,
         dataset=dataset,
@@ -339,7 +452,6 @@ def _deserialize_camera(
         modality_key=modality_key,
         channel_type=camera_metadata.channel_type,
     )
-    camera_to_global_se3 = PoseSE3.from_list(camera_to_global_se3_data)
     assert image is not None, "Failed to load camera image from Arrow table data."
     return Camera(
         metadata=camera_metadata,

--- a/src/py123d/api/scene/arrow/modalities/arrow_ego_state_se3.py
+++ b/src/py123d/api/scene/arrow/modalities/arrow_ego_state_se3.py
@@ -13,6 +13,7 @@ from py123d.datatypes.time.timestamp import Timestamp
 from py123d.datatypes.vehicle_state.dynamic_state import DynamicStateSE3, DynamicStateSE3Index
 from py123d.datatypes.vehicle_state.ego_state import EgoStateSE3
 from py123d.datatypes.vehicle_state.ego_state_metadata import EgoStateSE3Metadata
+from py123d.datatypes.vehicle_state.ego_uncertainty import EgoQualityFlag, EgoUncertaintySE3, EgoUncertaintySE3Index
 from py123d.geometry.geometry_index import PoseSE3Index
 from py123d.geometry.pose import PoseSE3
 from py123d.geometry.utils.kinematics_se3 import (
@@ -22,6 +23,14 @@ from py123d.geometry.utils.kinematics_se3 import (
     rotate_to_body,
 )
 from py123d.geometry.vector import Vector3D
+
+# Written only when EgoStateSE3Metadata.has_uncertainty is set, so logs whose poses carry no
+# estimated uncertainty keep their original schema and still load.
+_UNCERTAINTY_FIELDS: tuple = (
+    ("uncertainty_se3", pa.list_(pa.float64(), len(EgoUncertaintySE3Index))),
+    ("quality_flags", pa.int32()),
+    ("fix_age_s", pa.float64()),
+)
 
 # ------------------------------------------------------------------------------------------------------------------
 # Writer
@@ -47,14 +56,14 @@ class ArrowEgoStateSE3Writer(ArrowBaseModalityWriter):
         self._deferred_count: int = 0  # frames accepted but not yet emitted
 
         file_path = log_dir / f"{metadata.modality_key}.arrow"
-        schema = pa.schema(
-            [
-                (f"{self._metadata.modality_key}.timestamp_us", pa.int64()),
-                (f"{self._metadata.modality_key}.imu_se3", pa.list_(pa.float64(), len(PoseSE3Index))),
-                (f"{self._metadata.modality_key}.dynamic_state_se3", pa.list_(pa.float64(), len(DynamicStateSE3Index))),
-            ]
-        )
-        schema = add_metadata_to_arrow_schema(schema, metadata)
+        fields = [
+            (f"{self._metadata.modality_key}.timestamp_us", pa.int64()),
+            (f"{self._metadata.modality_key}.imu_se3", pa.list_(pa.float64(), len(PoseSE3Index))),
+            (f"{self._metadata.modality_key}.dynamic_state_se3", pa.list_(pa.float64(), len(DynamicStateSE3Index))),
+        ]
+        if metadata.has_uncertainty:
+            fields.extend((f"{self._metadata.modality_key}.{name}", dtype) for name, dtype in _UNCERTAINTY_FIELDS)
+        schema = add_metadata_to_arrow_schema(pa.schema(fields), metadata)
         super().__init__(
             file_path=file_path,
             schema=schema,
@@ -105,13 +114,26 @@ class ArrowEgoStateSE3Writer(ArrowBaseModalityWriter):
         super().close()
 
     def _emit(self, modality: EgoStateSE3) -> None:
-        self.write_batch(
-            {
-                f"{self._metadata.modality_key}.timestamp_us": [modality.timestamp.time_us],
-                f"{self._metadata.modality_key}.imu_se3": [modality.imu_se3],
-                f"{self._metadata.modality_key}.dynamic_state_se3": [modality.dynamic_state_se3],
-            }
-        )
+        key = self._metadata.modality_key
+        row: Dict[str, Any] = {
+            f"{key}.timestamp_us": [modality.timestamp.time_us],
+            f"{key}.imu_se3": [modality.imu_se3],
+            f"{key}.dynamic_state_se3": [modality.dynamic_state_se3],
+        }
+        if self._metadata.has_uncertainty:
+            # inf is not representable in Arrow's float64 in a way consumers handle uniformly, and
+            # "no fix yet" is genuinely absent rather than infinitely old, so it is written null.
+            fix_age = modality.fix_age_s
+            row[f"{key}.uncertainty_se3"] = [modality.uncertainty_se3]
+            row[f"{key}.quality_flags"] = [None if modality.quality_flags is None else int(modality.quality_flags)]
+            row[f"{key}.fix_age_s"] = [None if fix_age is None or not np.isfinite(fix_age) else float(fix_age)]
+        elif modality.uncertainty_se3 is not None:
+            warn(
+                "Ego state carries uncertainty but EgoStateSE3Metadata.has_uncertainty is False; "
+                "the values would be silently dropped.",
+                category=UserWarning,
+            )
+        self.write_batch(row)
 
 
 def _zero_dynamic_state_se3() -> DynamicStateSE3:
@@ -129,6 +151,9 @@ def _with_dynamics(state: EgoStateSE3, dynamic_state: DynamicStateSE3) -> EgoSta
         timestamp=state.timestamp,
         dynamic_state_se3=dynamic_state,
         tire_steering_angle=state.tire_steering_angle if state.tire_steering_angle is not None else 0.0,
+        uncertainty_se3=state.uncertainty_se3,
+        quality_flags=state.quality_flags,
+        fix_age_s=state.fix_age_s,
     )
 
 
@@ -231,8 +256,9 @@ class ArrowEgoStateSE3Reader(ArrowBaseModalityReader):
         column_at_iteration: Optional[Any] = None
         if full_column_name in table.column_names:
             column_at_iteration = table[full_column_name][index].as_py()
-            if deserialize and column in EGO_STATE_SE3_DESERIALIZE_FUNC:
-                column_at_iteration = EGO_STATE_SE3_DESERIALIZE_FUNC[column](column_at_iteration)
+            deserializers = {**EGO_STATE_SE3_DESERIALIZE_FUNC, **EGO_STATE_SE3_OPTIONAL_DESERIALIZE_FUNC}
+            if deserialize and column in deserializers:
+                column_at_iteration = deserializers[column](column_at_iteration)
         else:
             raise ValueError(
                 f"Column '{full_column_name}' not found in Arrow table for modality '{metadata.modality_key}'"
@@ -245,6 +271,14 @@ EGO_STATE_SE3_DESERIALIZE_FUNC: Dict[str, Callable[[Any], Any]] = {
     "imu_se3": PoseSE3.from_list,
     "dynamic_state_se3": lambda v: get_optional_array_mixin(data=v, cls=DynamicStateSE3),
     "timestamp_us": Timestamp.from_us,
+}
+
+# Deserializers for the optional columns. Kept apart from the required ones above, which decide
+# whether a row can be read at all.
+EGO_STATE_SE3_OPTIONAL_DESERIALIZE_FUNC: Dict[str, Callable[[Any], Any]] = {
+    "uncertainty_se3": lambda v: get_optional_array_mixin(data=v, cls=EgoUncertaintySE3),
+    "quality_flags": lambda v: None if v is None else EgoQualityFlag(int(v)),
+    "fix_age_s": lambda v: None if v is None else float(v),
 }
 
 
@@ -267,9 +301,18 @@ def _deserialize_ego_state_se3(
     dynamic_state_se3 = EGO_STATE_SE3_DESERIALIZE_FUNC["dynamic_state_se3"](
         modality_table[f"{modality_key}.dynamic_state_se3"][index].as_py()
     )
+    optional = {
+        name: deserialize(modality_table[f"{modality_key}.{name}"][index].as_py())
+        if f"{modality_key}.{name}" in modality_table.column_names
+        else None
+        for name, deserialize in EGO_STATE_SE3_OPTIONAL_DESERIALIZE_FUNC.items()
+    }
     return EgoStateSE3.from_imu(
         imu_se3=imu_se3,
         metadata=metadata,
         dynamic_state_se3=dynamic_state_se3,  # type: ignore
         timestamp=timestamp,
+        uncertainty_se3=optional["uncertainty_se3"],  # type: ignore
+        quality_flags=optional["quality_flags"],  # type: ignore
+        fix_age_s=optional["fix_age_s"],  # type: ignore
     )

--- a/src/py123d/api/scene/arrow/modalities/arrow_gnss.py
+++ b/src/py123d/api/scene/arrow/modalities/arrow_gnss.py
@@ -23,6 +23,7 @@ _SOLUTION_QUALITY_FIELDS: tuple = (
     ("vertical_accuracy", pa.float64()),
     ("position_dop", pa.float64()),
     ("velocity_ned", pa.list_(pa.float64(), _VELOCITY_SIZE)),
+    ("speed_accuracy", pa.float64()),
 )
 
 # ------------------------------------------------------------------------------------------------------------------
@@ -137,6 +138,7 @@ class ArrowGnssReader(ArrowBaseModalityReader):
             vertical_accuracy=_optional("vertical_accuracy"),
             position_dop=_optional("position_dop"),
             velocity_ned=np.asarray(velocity_ned, dtype=np.float64) if velocity_ned is not None else None,
+            speed_accuracy=_optional("speed_accuracy"),
         )
 
     @staticmethod

--- a/src/py123d/datatypes/sensors/gnss.py
+++ b/src/py123d/datatypes/sensors/gnss.py
@@ -143,6 +143,7 @@ class Gnss(BaseModality):
         "_vertical_accuracy",
         "_position_dop",
         "_velocity_ned",
+        "_speed_accuracy",
     )
 
     def __init__(
@@ -162,6 +163,7 @@ class Gnss(BaseModality):
         vertical_accuracy: Optional[float] = None,
         position_dop: Optional[float] = None,
         velocity_ned: Optional[npt.NDArray[np.float64]] = None,
+        speed_accuracy: Optional[float] = None,
     ) -> None:
         """Initialize a GNSS fix.
 
@@ -181,6 +183,9 @@ class Gnss(BaseModality):
         :param vertical_accuracy: Optional reported 1-sigma vertical accuracy in meters.
         :param position_dop: Optional position dilution of precision.
         :param velocity_ned: Optional (north, east, down) velocity in m/s.
+        :param speed_accuracy: Optional reported 1-sigma accuracy of that velocity in m/s. The
+            velocity's counterpart to :attr:`horizontal_accuracy`, and what a consumer fusing the
+            velocity needs in order to weight it.
         """
         self._timestamp = timestamp
         self._metadata = metadata
@@ -197,6 +202,7 @@ class Gnss(BaseModality):
         self._vertical_accuracy = vertical_accuracy
         self._position_dop = position_dop
         self._velocity_ned = velocity_ned
+        self._speed_accuracy = speed_accuracy
 
     @property
     def timestamp(self) -> Timestamp:
@@ -277,6 +283,11 @@ class Gnss(BaseModality):
     def velocity_ned(self) -> Optional[npt.NDArray[np.float64]]:
         """(north, east, down) velocity in m/s as a (3,) array, or None if not reported."""
         return self._velocity_ned
+
+    @property
+    def speed_accuracy(self) -> Optional[float]:
+        """Reported 1-sigma accuracy of :attr:`velocity_ned` in m/s, if the receiver supplied it."""
+        return self._speed_accuracy
 
     @property
     def ground_speed(self) -> Optional[float]:

--- a/src/py123d/datatypes/vehicle_state/ego_state.py
+++ b/src/py123d/datatypes/vehicle_state/ego_state.py
@@ -18,6 +18,7 @@ from py123d.datatypes.vehicle_state.ego_state_metadata import (
     rear_axle_se2_to_imu_se2,
     rear_axle_se3_to_imu_se3,
 )
+from py123d.datatypes.vehicle_state.ego_uncertainty import EgoQualityFlag, EgoUncertaintySE3
 from py123d.geometry import BoundingBoxSE2, BoundingBoxSE3, Point2D, Point3D, PoseSE2, PoseSE3, Vector2D, Vector3D
 
 EGO_TRACK_TOKEN: Final[str] = "ego_vehicle"
@@ -36,6 +37,9 @@ class EgoStateSE3(BaseModality):
         "_timestamp",
         "_dynamic_state_se3",
         "_tire_steering_angle",
+        "_uncertainty_se3",
+        "_quality_flags",
+        "_fix_age_s",
     )
 
     _imu_se3: PoseSE3
@@ -43,6 +47,9 @@ class EgoStateSE3(BaseModality):
     _timestamp: Timestamp
     _dynamic_state_se3: Optional[DynamicStateSE3]
     _tire_steering_angle: Optional[float]
+    _uncertainty_se3: Optional[EgoUncertaintySE3]
+    _quality_flags: Optional[EgoQualityFlag]
+    _fix_age_s: Optional[float]
 
     @classmethod
     def from_imu(
@@ -52,6 +59,9 @@ class EgoStateSE3(BaseModality):
         timestamp: Timestamp,
         dynamic_state_se3: Optional[DynamicStateSE3] = None,
         tire_steering_angle: float = 0.0,
+        uncertainty_se3: Optional[EgoUncertaintySE3] = None,
+        quality_flags: Optional[EgoQualityFlag] = None,
+        fix_age_s: Optional[float] = None,
     ) -> EgoStateSE3:
         """Create an :class:`EgoStateSE3` from the IMU pose.
 
@@ -62,6 +72,9 @@ class EgoStateSE3(BaseModality):
         :param timestamp: The timestamp of the state.
         :param dynamic_state_se3: The dynamic state of the vehicle, defaults to None.
         :param tire_steering_angle: The tire steering angle, defaults to 0.0.
+        :param uncertainty_se3: Per-component one-sigma uncertainty, if the source estimated it.
+        :param quality_flags: What was correcting the state at this instant, if known.
+        :param fix_age_s: Seconds since the last absolute position update, if known.
         :return: An :class:`EgoStateSE3` instance.
         """
         instance = object.__new__(cls)
@@ -70,6 +83,9 @@ class EgoStateSE3(BaseModality):
         instance._timestamp = timestamp
         instance._dynamic_state_se3 = dynamic_state_se3
         instance._tire_steering_angle = tire_steering_angle
+        instance._uncertainty_se3 = uncertainty_se3
+        instance._quality_flags = quality_flags
+        instance._fix_age_s = fix_age_s
         return instance
 
     @classmethod
@@ -167,6 +183,25 @@ class EgoStateSE3(BaseModality):
     def dynamic_state_se3(self) -> Optional[DynamicStateSE3]:
         """The :class:`~py123d.datatypes.vehicle_state.DynamicStateSE3` of the vehicle."""
         return self._dynamic_state_se3
+
+    @property
+    def uncertainty_se3(self) -> Optional[EgoUncertaintySE3]:
+        """Per-component one-sigma uncertainty of this state, or None if the source had none."""
+        return self._uncertainty_se3
+
+    @property
+    def quality_flags(self) -> Optional[EgoQualityFlag]:
+        """What was correcting the state at this instant, or None if the source had no such notion."""
+        return self._quality_flags
+
+    @property
+    def fix_age_s(self) -> Optional[float]:
+        """Seconds since the last absolute position update, or None if unknown.
+
+        Large values mean the pose is dead reckoning and its error is growing; ``inf`` means no
+        absolute position has been seen at all yet.
+        """
+        return self._fix_age_s
 
     @property
     def timestamp(self) -> Timestamp:
@@ -384,6 +419,25 @@ class EgoStateSE2:
     def metadata(self) -> EgoStateSE3Metadata:
         """The :class:`~py123d.datatypes.EgoStateSE3Metadata` of the vehicle."""
         return self._metadata
+
+    @property
+    def uncertainty_se3(self) -> Optional[EgoUncertaintySE3]:
+        """Per-component one-sigma uncertainty of this state, or None if the source had none."""
+        return self._uncertainty_se3
+
+    @property
+    def quality_flags(self) -> Optional[EgoQualityFlag]:
+        """What was correcting the state at this instant, or None if the source had no such notion."""
+        return self._quality_flags
+
+    @property
+    def fix_age_s(self) -> Optional[float]:
+        """Seconds since the last absolute position update, or None if unknown.
+
+        Large values mean the pose is dead reckoning and its error is growing; ``inf`` means no
+        absolute position has been seen at all yet.
+        """
+        return self._fix_age_s
 
     @property
     def timestamp(self) -> Timestamp:

--- a/src/py123d/datatypes/vehicle_state/ego_state_metadata.py
+++ b/src/py123d/datatypes/vehicle_state/ego_state_metadata.py
@@ -8,7 +8,16 @@ from py123d.geometry.transform import abs_to_rel_se2, abs_to_rel_se3, rel_to_abs
 class EgoStateSE3Metadata(BaseModalityMetadata):
     """Metadata that describes the physical dimensions of the ego vehicle."""
 
-    __slots__ = ("vehicle_name", "width", "length", "height", "wheel_base", "center_to_imu_se3", "rear_axle_to_imu_se3")
+    __slots__ = (
+        "vehicle_name",
+        "width",
+        "length",
+        "height",
+        "wheel_base",
+        "center_to_imu_se3",
+        "rear_axle_to_imu_se3",
+        "has_uncertainty",
+    )
 
     vehicle_name: str
     """Name of the vehicle model."""
@@ -39,6 +48,14 @@ class EgoStateSE3Metadata(BaseModalityMetadata):
     datasets where the IMU is co-located with the rear axle.
     """
 
+    has_uncertainty: bool
+    """Whether the ego states of this log carry per-frame uncertainty and quality columns.
+
+    Set by parsers whose ego poses come from an estimator that reports its own covariance. Logs
+    written before those columns existed, or by a parser that only has poses, keep the original
+    schema and read the fields back as None.
+    """
+
     def __init__(
         self,
         vehicle_name: str,
@@ -48,6 +65,7 @@ class EgoStateSE3Metadata(BaseModalityMetadata):
         wheel_base: float,
         center_to_imu_se3: PoseSE3,
         rear_axle_to_imu_se3: PoseSE3,
+        has_uncertainty: bool = False,
     ) -> None:
         self.vehicle_name = vehicle_name
         self.width = width
@@ -56,6 +74,7 @@ class EgoStateSE3Metadata(BaseModalityMetadata):
         self.wheel_base = wheel_base
         self.center_to_imu_se3 = center_to_imu_se3
         self.rear_axle_to_imu_se3 = rear_axle_to_imu_se3
+        self.has_uncertainty = has_uncertainty
 
     @classmethod
     def from_dict(cls, data_dict: dict) -> EgoStateSE3Metadata:

--- a/src/py123d/datatypes/vehicle_state/ego_uncertainty.py
+++ b/src/py123d/datatypes/vehicle_state/ego_uncertainty.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from enum import IntEnum, IntFlag
+
+import numpy as np
+import numpy.typing as npt
+
+from py123d.common.utils.enums import classproperty
+from py123d.common.utils.mixin import ArrayMixin
+from py123d.geometry import Vector3D
+
+
+class EgoUncertaintySE3Index(IntEnum):
+    """The indices for the ego state uncertainty in SE3."""
+
+    POSITION_SIGMA_X = 0
+    """One-sigma position uncertainty along the global X axis (east), meters."""
+
+    POSITION_SIGMA_Y = 1
+    """One-sigma position uncertainty along the global Y axis (north), meters."""
+
+    POSITION_SIGMA_Z = 2
+    """One-sigma position uncertainty along the global Z axis (up), meters."""
+
+    VELOCITY_SIGMA_X = 3
+    """One-sigma velocity uncertainty in the ego frame X direction (forward), m/s."""
+
+    VELOCITY_SIGMA_Y = 4
+    """One-sigma velocity uncertainty in the ego frame Y direction (left), m/s."""
+
+    VELOCITY_SIGMA_Z = 5
+    """One-sigma velocity uncertainty in the ego frame Z direction (up), m/s."""
+
+    ORIENTATION_SIGMA_ROLL = 6
+    """One-sigma roll uncertainty, radians."""
+
+    ORIENTATION_SIGMA_PITCH = 7
+    """One-sigma pitch uncertainty, radians."""
+
+    ORIENTATION_SIGMA_YAW = 8
+    """One-sigma yaw uncertainty, radians."""
+
+    @classproperty
+    def POSITION_SIGMA_3D(cls) -> slice:
+        """Slice for the 3D position uncertainty components (x,y,z)."""
+        return slice(cls.POSITION_SIGMA_X, cls.POSITION_SIGMA_Z + 1)
+
+    @classproperty
+    def VELOCITY_SIGMA_3D(cls) -> slice:
+        """Slice for the 3D velocity uncertainty components (x,y,z)."""
+        return slice(cls.VELOCITY_SIGMA_X, cls.VELOCITY_SIGMA_Z + 1)
+
+    @classproperty
+    def ORIENTATION_SIGMA_3D(cls) -> slice:
+        """Slice for the 3D orientation uncertainty components (roll,pitch,yaw)."""
+        return slice(cls.ORIENTATION_SIGMA_ROLL, cls.ORIENTATION_SIGMA_YAW + 1)
+
+
+class EgoQualityFlag(IntFlag):
+    """What was supporting the ego state at one instant.
+
+    A pose estimator is corrected by different sources at different rates, and its covariance
+    alone does not say which. These flags do, so a consumer can select the stretches a given
+    source was actually present for -- or reject the ones where nothing but dead reckoning was.
+    """
+
+    NONE = 0
+    """Nothing corrected the state here: it is dead reckoning."""
+
+    GNSS_POSITION = 1 << 0
+    """A GNSS position was applied recently."""
+
+    GNSS_VELOCITY = 1 << 1
+    """A GNSS velocity solution was applied recently."""
+
+    RADAR_VELOCITY = 1 << 2
+    """A radar Doppler velocity was applied recently."""
+
+    ZERO_VELOCITY = 1 << 3
+    """The vehicle was detected to be stationary and a zero-velocity update was applied."""
+
+    NON_HOLONOMIC = 1 << 4
+    """The vehicle-motion (no side slip) constraint was applied."""
+
+    BAROMETER = 1 << 5
+    """A barometric height measurement was applied recently."""
+
+    OUTLIER_GATED = 1 << 6
+    """A measurement disagreed with the state and was down-weighted. Treat the epoch as suspect."""
+
+
+class EgoUncertaintySE3(ArrayMixin):
+    """The uncertainty of an ego state in SE3, as one sigma per component.
+
+    Position uncertainty is in the global frame and velocity uncertainty in the ego frame, each
+    matching the frame its quantity is expressed in on :class:`~py123d.datatypes.vehicle_state.
+    ego_state.EgoStateSE3`. Only the marginal standard deviations are kept, not the full
+    covariance: they are what a consumer selecting or weighting frames actually uses, and they
+    cost nine numbers a frame instead of a hundred and thirty-six.
+    """
+
+    __slots__ = ("_array",)
+    _array: npt.NDArray[np.float64]
+
+    def __init__(
+        self,
+        position_sigma: Vector3D,
+        velocity_sigma: Vector3D,
+        orientation_sigma: Vector3D,
+    ):
+        """Initialize an :class:`EgoUncertaintySE3` instance.
+
+        :param position_sigma: One-sigma position uncertainty in the global frame, meters.
+        :param velocity_sigma: One-sigma velocity uncertainty in the ego frame, m/s.
+        :param orientation_sigma: One-sigma roll/pitch/yaw uncertainty, radians.
+        """
+        array = np.zeros(len(EgoUncertaintySE3Index), dtype=np.float64)
+        array[EgoUncertaintySE3Index.POSITION_SIGMA_3D] = position_sigma.array
+        array[EgoUncertaintySE3Index.VELOCITY_SIGMA_3D] = velocity_sigma.array
+        array[EgoUncertaintySE3Index.ORIENTATION_SIGMA_3D] = orientation_sigma.array
+        self._array = array
+
+    @classmethod
+    def from_array(cls, array: npt.NDArray[np.float64], copy: bool = True) -> EgoUncertaintySE3:
+        """Create an :class:`EgoUncertaintySE3` from a NumPy array of shape (9,).
+
+        :param array: The array, indexed by :class:`EgoUncertaintySE3Index`.
+        :param copy: Whether to copy the array data.
+        :return: An :class:`EgoUncertaintySE3` instance.
+        """
+        assert array.ndim == 1
+        assert array.shape[0] == len(EgoUncertaintySE3Index)
+        instance = object.__new__(cls)
+        instance._array = array.copy() if copy else array
+        return instance
+
+    @property
+    def position_sigma(self) -> Vector3D:
+        """One-sigma position uncertainty in the global frame, meters."""
+        return Vector3D.from_array(self._array[EgoUncertaintySE3Index.POSITION_SIGMA_3D], copy=False)
+
+    @property
+    def velocity_sigma(self) -> Vector3D:
+        """One-sigma velocity uncertainty in the ego frame, m/s."""
+        return Vector3D.from_array(self._array[EgoUncertaintySE3Index.VELOCITY_SIGMA_3D], copy=False)
+
+    @property
+    def orientation_sigma(self) -> Vector3D:
+        """One-sigma roll/pitch/yaw uncertainty, radians."""
+        return Vector3D.from_array(self._array[EgoUncertaintySE3Index.ORIENTATION_SIGMA_3D], copy=False)
+
+    @property
+    def horizontal_position_sigma(self) -> float:
+        """One-sigma horizontal position uncertainty, meters."""
+        return float(
+            np.hypot(*self._array[EgoUncertaintySE3Index.POSITION_SIGMA_X : EgoUncertaintySE3Index.POSITION_SIGMA_Z])
+        )
+
+    @property
+    def array(self) -> npt.NDArray[np.float64]:
+        """NumPy array representation of shape (9,), indexed by :class:`EgoUncertaintySE3Index`."""
+        return self._array
+
+    def __repr__(self) -> str:
+        return (
+            f"EgoUncertaintySE3(position_sigma={self.position_sigma}, "
+            f"velocity_sigma={self.velocity_sigma}, orientation_sigma={self.orientation_sigma})"
+        )

--- a/src/py123d/parser/base_dataset_parser.py
+++ b/src/py123d/parser/base_dataset_parser.py
@@ -192,13 +192,17 @@ class ParsedRadar(BaseModality):
 
 
 class ParsedCamera(BaseModality):
-    """Helper modality to pass cameras to log writer without loading loading an image/video or decoding the bytestring."""
+    """Helper modality to pass cameras to log writer without loading loading an image/video or decoding the bytestring.
+
+    ``camera_to_global_se3`` may be None, in which case the writer stores a null and the reader
+    composes the pose from the log's ego trajectory and the camera's own extrinsic.
+    """
 
     def __init__(
         self,
         metadata: Union[PinholeCameraMetadata, FisheyeMEICameraMetadata, FThetaCameraMetadata],
         timestamp: Timestamp,
-        camera_to_global_se3: PoseSE3,
+        camera_to_global_se3: Optional[PoseSE3],
         dataset_root: Optional[Union[str, Path]] = None,
         relative_path: Optional[Union[str, Path]] = None,
         byte_string: Optional[bytes] = None,
@@ -228,8 +232,13 @@ class ParsedCamera(BaseModality):
         return self._metadata
 
     @property
-    def camera_to_global_se3(self) -> PoseSE3:
-        """Returns the camera-to-global pose associated with this camera data."""
+    def camera_to_global_se3(self) -> Optional[PoseSE3]:
+        """Returns the camera-to-global pose associated with this camera data.
+
+        None where the dataset stores the pose implicitly. It is then written as a null and
+        composed on read from ``ego_state_se3`` and the camera extrinsic, which is what lets a
+        re-estimated ego trajectory reach the camera poses without rewriting the image tables.
+        """
         return self._camera_to_global_se3
 
     @property

--- a/tests/unit/api/scene/arrow/test_camera_pose_from_ego.py
+++ b/tests/unit/api/scene/arrow/test_camera_pose_from_ego.py
@@ -1,0 +1,194 @@
+"""A camera pose stored as null must be composed from the ego trajectory on read.
+
+``camera_to_global_se3`` is ego_pose composed with the camera extrinsic, and it is the only
+per-frame field a change to the ego trajectory invalidates. Storing it as a null and composing it
+on read is what lets a re-estimated trajectory reach the camera poses by rewriting
+``ego_state_se3.arrow`` alone instead of every image table -- megabytes rather than tens of
+gigabytes. These tests pin both halves of that: the composed pose has to equal what eager
+composition would have written, and a log that carries the column has to keep reading its own
+stored value untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+
+from py123d.api.scene.arrow.modalities.arrow_camera import ArrowCameraReader, ArrowCameraWriter
+from py123d.api.scene.arrow.modalities.arrow_ego_state_se3 import ArrowEgoStateSE3Writer
+from py123d.datatypes import Timestamp
+from py123d.datatypes.sensors.base_camera import Camera, CameraID
+from py123d.datatypes.sensors.pinhole_camera import PinholeCameraMetadata, PinholeDistortion, PinholeIntrinsics
+from py123d.datatypes.vehicle_state.dynamic_state import DynamicStateSE3
+from py123d.datatypes.vehicle_state.ego_state import EgoStateSE3
+from py123d.datatypes.vehicle_state.ego_state_metadata import EgoStateSE3Metadata
+from py123d.geometry.pose import PoseSE3
+from py123d.geometry.transform.transform_se3 import rel_to_abs_se3
+from py123d.geometry.vector import Vector3D
+from py123d.parser.base_dataset_parser import ParsedCamera
+
+_CAMERA_TO_IMU = PoseSE3(x=1.5, y=-0.2, z=1.4, qw=0.5, qx=-0.5, qy=0.5, qz=-0.5)
+_RATE_US = 10_000  # 100 Hz ego states
+_COUNT = 50
+
+
+def _camera_metadata() -> PinholeCameraMetadata:
+    return PinholeCameraMetadata(
+        camera_name="front_camera",
+        camera_id=CameraID.PCAM_F0,
+        intrinsics=PinholeIntrinsics(fx=500.0, fy=500.0, cx=320.0, cy=240.0),
+        distortion=PinholeDistortion(k1=0.0, k2=0.0, p1=0.0, p2=0.0, k3=0.0),
+        width=64,
+        height=48,
+        camera_to_imu_se3=_CAMERA_TO_IMU,
+    )
+
+
+def _ego_metadata() -> EgoStateSE3Metadata:
+    return EgoStateSE3Metadata(
+        vehicle_name="test",
+        width=1.8,
+        length=4.5,
+        height=1.5,
+        wheel_base=2.7,
+        center_to_imu_se3=PoseSE3.identity(),
+        rear_axle_to_imu_se3=PoseSE3.identity(),
+    )
+
+
+def _ego_pose(index: int) -> PoseSE3:
+    """A gentle turn, so interpolation of both translation and rotation is exercised."""
+    yaw = 0.004 * index
+    return PoseSE3(
+        x=2.0 * index,
+        y=0.05 * index * index,
+        z=0.01 * index,
+        qw=float(np.cos(yaw / 2.0)),
+        qx=0.0,
+        qy=0.0,
+        qz=float(np.sin(yaw / 2.0)),
+    )
+
+
+def _write_ego(log_dir: Path) -> None:
+    writer = ArrowEgoStateSE3Writer(log_dir=log_dir, metadata=_ego_metadata())
+    for index in range(_COUNT):
+        writer.write_modality(
+            EgoStateSE3.from_imu(
+                imu_se3=_ego_pose(index),
+                metadata=_ego_metadata(),
+                timestamp=Timestamp.from_us(index * _RATE_US),
+                dynamic_state_se3=DynamicStateSE3(
+                    velocity=Vector3D(0.0, 0.0, 0.0),
+                    acceleration=Vector3D(0.0, 0.0, 0.0),
+                    angular_velocity=Vector3D(0.0, 0.0, 0.0),
+                ),
+            )
+        )
+    writer.close()
+
+
+def _write_cameras(log_dir: Path, stamps_us: list, pose: bool) -> pa.Table:
+    metadata = _camera_metadata()
+    writer = ArrowCameraWriter(log_dir=log_dir, metadata=metadata, camera_codec="jpeg_binary")
+    image = np.zeros((48, 64, 3), dtype=np.uint8)
+    for stamp in stamps_us:
+        writer.write_modality(
+            Camera(
+                metadata=metadata,
+                image=image,
+                camera_to_global_se3=rel_to_abs_se3(origin=_ego_pose(stamp // _RATE_US), pose_se3=_CAMERA_TO_IMU)
+                if pose
+                else None,
+                timestamp=Timestamp.from_us(stamp),
+            )
+        )
+    writer.close()
+    return pa.ipc.open_file(str(log_dir / f"{metadata.modality_key}.arrow")).read_all()
+
+
+def test_null_pose_is_composed_from_the_ego_trajectory(tmp_path: Path) -> None:
+    """On a sample the ego states land on, the composed pose is the eager one exactly."""
+    _write_ego(tmp_path)
+    stamps = [index * _RATE_US for index in (0, 7, 23, _COUNT - 1)]
+    table = _write_cameras(tmp_path, stamps, pose=False)
+
+    assert table[f"{_camera_metadata().modality_key}.camera_to_global_se3"].null_count == len(stamps)
+    for row, stamp in enumerate(stamps):
+        camera = ArrowCameraReader.read_at_index(row, table, _camera_metadata(), "test", log_dir=tmp_path)
+        assert camera is not None, "a null pose column made the frame unreadable"
+        expected = rel_to_abs_se3(origin=_ego_pose(stamp // _RATE_US), pose_se3=_CAMERA_TO_IMU)
+        assert np.allclose(camera.camera_to_global_se3.tolist(), expected.tolist(), atol=1e-9)
+
+
+def test_a_frame_between_ego_samples_is_interpolated(tmp_path: Path) -> None:
+    """Snapping to the nearest 100 Hz state would displace the camera by up to 5 ms of travel."""
+    _write_ego(tmp_path)
+    midpoint = 10 * _RATE_US + _RATE_US // 2
+    table = _write_cameras(tmp_path, [midpoint], pose=False)
+
+    camera = ArrowCameraReader.read_at_index(0, table, _camera_metadata(), "test", log_dir=tmp_path)
+    assert camera is not None
+    composed = np.array(camera.camera_to_global_se3.tolist())
+    lower = np.array(rel_to_abs_se3(origin=_ego_pose(10), pose_se3=_CAMERA_TO_IMU).tolist())
+    upper = np.array(rel_to_abs_se3(origin=_ego_pose(11), pose_se3=_CAMERA_TO_IMU).tolist())
+    assert np.allclose(composed[:3], 0.5 * (lower[:3] + upper[:3]), atol=1e-9), "translation was not interpolated"
+    assert not np.allclose(composed[:3], lower[:3]), "the pose snapped to the nearest ego state"
+
+
+def test_a_stored_pose_is_never_recomputed(tmp_path: Path) -> None:
+    """Backward compatibility: a log that wrote the column reads its own value, not a composed one.
+
+    The stored pose here is deliberately inconsistent with the ego trajectory in the same
+    directory, so anything recomputing it would be caught.
+    """
+    _write_ego(tmp_path)
+    stored = PoseSE3(x=999.0, y=-42.0, z=7.0, qw=1.0, qx=0.0, qy=0.0, qz=0.0)
+    metadata = _camera_metadata()
+    writer = ArrowCameraWriter(log_dir=tmp_path, metadata=metadata, camera_codec="jpeg_binary")
+    writer.write_modality(
+        Camera(
+            metadata=metadata,
+            image=np.zeros((48, 64, 3), dtype=np.uint8),
+            camera_to_global_se3=stored,
+            timestamp=Timestamp.from_us(3 * _RATE_US),
+        )
+    )
+    writer.close()
+    table = pa.ipc.open_file(str(tmp_path / f"{metadata.modality_key}.arrow")).read_all()
+
+    camera = ArrowCameraReader.read_at_index(0, table, metadata, "test", log_dir=tmp_path)
+    assert camera is not None
+    assert np.allclose(camera.camera_to_global_se3.tolist(), stored.tolist())
+
+
+def test_the_column_reader_composes_too(tmp_path: Path) -> None:
+    """read_column_at_index is a separate path and has to give the same answer."""
+    _write_ego(tmp_path)
+    table = _write_cameras(tmp_path, [5 * _RATE_US], pose=False)
+
+    pose = ArrowCameraReader.read_column_at_index(
+        0, table, _camera_metadata(), "camera_to_global_se3", "test", deserialize=True, log_dir=tmp_path
+    )
+    assert pose is not None, "the column reader returned nothing for an implicitly stored pose"
+    expected = rel_to_abs_se3(origin=_ego_pose(5), pose_se3=_CAMERA_TO_IMU)
+    assert np.allclose(pose.tolist(), expected.tolist(), atol=1e-9)
+
+
+def test_a_null_pose_without_an_ego_trajectory_reads_as_absent(tmp_path: Path) -> None:
+    """No ego states means the pose genuinely cannot be known; the frame is reported as absent."""
+    table = _write_cameras(tmp_path, [0], pose=False)
+    assert ArrowCameraReader.read_at_index(0, table, _camera_metadata(), "test", log_dir=tmp_path) is None
+
+
+def test_a_parsed_camera_accepts_no_pose() -> None:
+    """The writer-side type has to allow it, or a parser cannot express an implicit pose."""
+    camera = ParsedCamera(
+        metadata=_camera_metadata(),
+        timestamp=Timestamp.from_us(0),
+        camera_to_global_se3=None,
+        byte_string=b"not-an-image",
+    )
+    assert camera.camera_to_global_se3 is None


### PR DESCRIPTION
## What this adds

Three schema-level additions required by the KESAI data reader. All are backward compatible: logs converted before these fields existed keep their schema and read the new fields back as None.

### 1. Ego state carries the uncertainty and quality of the pose that produced it (28da4b3)
- `EgoUncertaintySE3`: per-sample one-sigma position, velocity and attitude uncertainty on `ego_state_se3.arrow`.
- `EgoQualityFlag`: a bitfield naming what was correcting the estimator at that sample (GNSS position/velocity, zero-velocity update, non-holonomic constraint, outlier gated), plus `fix_age_s`, the time since a GNSS position was applied.
- Consumers can select samples in a more informed way. 

### 2. GNSS: store the receiver's speed accuracy (b67476d)
- `gnss.speed_accuracy` (sAcc) next to the existing horizontal/vertical accuracy columns.
- The estimator weights the receiver's Doppler velocity by it, and the reports display it. 

### 3. Camera: allow the world pose to be stored implicitly and composed on read (a1f04cc)
- A camera table may store a null `camera_to_global_se3`; readers compose `ego_pose * camera_to_imu` on access.
- This makes the ego trajectory re-estimable after conversion: rewriting `ego_state_se3.arrow` updates every camera world pose with it, instead of leaving stale poses baked into terabytes of camera tables.