### PR TITLE
Add option to give a map root explicitly for mixed dataset training

### DIFF
--- a/src/py123d/api/map/arrow/arrow_map_api.py
+++ b/src/py123d/api/map/arrow/arrow_map_api.py
@@ -523,23 +523,31 @@ def get_lru_cached_map_api(arrow_file_path: Union[Path, str]) -> ArrowMapAPI:
     return map_api
 
 
-def get_map_api_for_log(log_dir: Path, log_metadata: LogMetadata) -> Optional[ArrowMapAPI]:
-    """Get the map API for a given log metadata, if map metadata is available."""
+def get_map_api_for_log(
+    log_dir: Path, log_metadata: LogMetadata, maps_root: Optional[Path] = None
+) -> Optional[ArrowMapAPI]:
+    """Get the map API for a given log metadata, if map metadata is available.
+
+    :param log_dir: The log directory, checked for a per-log ``map.arrow``.
+    :param log_metadata: Names the dataset and location of the global map file.
+    :param maps_root: Maps directory to check before the global dataset paths,
+        defaults to None
+    """
 
     def _resolve_map_file() -> Optional[Path]:
-        """Find the map file: first check per-log, then global maps directory."""
+        """Find the map file: per-log, then the given maps root, then the global one."""
         # 1. Per-log map
         map_file = log_dir / "map.arrow"
         if map_file.exists():
             return map_file
-        # 2. Global map
+        # 2. Given maps root, then global maps directory
         dataset, location = log_metadata.dataset, log_metadata.location
         if dataset is not None and location is not None:
-            maps_root = get_dataset_paths().py123d_maps_root
-            if maps_root is not None:
-                map_file = maps_root / dataset / f"{dataset}_{location}.arrow"
-                if map_file.exists():
-                    return map_file
+            for root in (maps_root, get_dataset_paths().py123d_maps_root):
+                if root is not None:
+                    map_file = root / dataset / f"{dataset}_{location}.arrow"
+                    if map_file.exists():
+                        return map_file
         return None
 
     map_api: Optional[ArrowMapAPI] = None

--- a/src/py123d/api/scene/arrow/arrow_scene_api.py
+++ b/src/py123d/api/scene/arrow/arrow_scene_api.py
@@ -61,24 +61,28 @@ MODALITY_READERS: Dict[ModalityType, Type[ArrowBaseModalityReader]] = {
 class ArrowSceneAPI(SceneAPI):
     """Scene API for Arrow-based scenes. Loads each modality from a separate Arrow file in a log directory."""
 
-    __slots__ = ("_log_dir", "_scene_metadata")
+    __slots__ = ("_log_dir", "_scene_metadata", "_maps_root")
 
     def __init__(
         self,
         log_dir: Union[Path, str],
         scene_metadata: Optional[SceneMetadata] = None,
+        maps_root: Optional[Union[Path, str]] = None,
     ) -> None:
         """Initializes the :class:`ArrowSceneAPI`.
 
         :param log_dir: Path to the log directory containing per-modality Arrow files.
         :param scene_metadata: Scene metadata, defaults to None
+        :param maps_root: Root directory the scene's map is resolved under before the
+            global dataset paths, defaults to None
         """
         self._log_dir: Path = Path(log_dir)
         self._scene_metadata: Optional[SceneMetadata] = scene_metadata
+        self._maps_root: Optional[Path] = Path(maps_root) if maps_root is not None else None
 
     def __reduce__(self):
         """Helper for pickling the object."""
-        return (self.__class__, (self._log_dir, self._scene_metadata))
+        return (self.__class__, (self._log_dir, self._scene_metadata, self._maps_root))
 
     # ------------------------------------------------------------------------------------------------------------------
     # Internal Helpers
@@ -147,7 +151,7 @@ class ArrowSceneAPI(SceneAPI):
 
     def get_map_api(self) -> Optional[MapAPI]:
         """Inherited, see superclass."""
-        return get_map_api_for_log(self._log_dir, self.get_log_metadata())
+        return get_map_api_for_log(self._log_dir, self.get_log_metadata(), maps_root=self._maps_root)
 
     # ------------------------------------------------------------------------------------------------------------------
     # 4. General modality access

--- a/src/py123d/api/scene/arrow/arrow_scene_builder.py
+++ b/src/py123d/api/scene/arrow/arrow_scene_builder.py
@@ -116,7 +116,7 @@ class LazyArrowSceneBuilder(ArrowSceneBuilder):
         target_uuids_binary = scene_uuids_to_binary(filter.scene_uuids) if filter.scene_uuids is not None else None
         log_indices = executor_map_chunked_list(
             executor,
-            partial(_index_log_dirs, filter=filter, target_uuids_binary=target_uuids_binary),
+            partial(_index_log_dirs, filter=filter, maps_root=self._maps_root, target_uuids_binary=target_uuids_binary),
             log_paths,
             name="Scene indexing",
         )
@@ -203,16 +203,18 @@ def _discover_split_names(logs_root: Path, filter: SceneFilter) -> List[str]:
 def _index_log_dirs(
     log_dirs: List[Path],
     filter: SceneFilter,
+    maps_root: Optional[Path] = None,
     target_uuids_binary: Optional[pa.Array] = None,
 ) -> List[LogSceneIndex]:
     """Index multiple log directories (chunked batch wrapper).
 
     :param log_dirs: List of log directory paths to index.
     :param filter: The scene filter.
+    :param maps_root: Maps directory the built scenes resolve their map under, defaults to None
     :param target_uuids_binary: Pre-converted binary(16) Arrow array of target UUIDs, or None.
     :return: One index per log that contributes at least one scene.
     """
-    indices = [build_log_scene_index(log_dir, filter, target_uuids_binary) for log_dir in log_dirs]
+    indices = [build_log_scene_index(log_dir, filter, target_uuids_binary, maps_root=maps_root) for log_dir in log_dirs]
     return [index for index in indices if index is not None]
 
 
@@ -259,7 +261,7 @@ def _extract_scenes_from_log_dir(
 
     scenes: List[SceneAPI] = []
     for scene_metadata in scene_metadatas:
-        scenes.append(ArrowSceneAPI(log_dir=log_dir, scene_metadata=scene_metadata))
+        scenes.append(ArrowSceneAPI(log_dir=log_dir, scene_metadata=scene_metadata, maps_root=maps_root))
     return scenes
 
 

--- a/src/py123d/api/scene/arrow/lazy_scene_sequence.py
+++ b/src/py123d/api/scene/arrow/lazy_scene_sequence.py
@@ -48,6 +48,9 @@ class LogSceneIndex:
     log_dir: Path
     """Directory the scenes are read from."""
 
+    maps_root: Optional[Path]
+    """Maps directory the scenes resolve their map under before the global dataset paths."""
+
     dataset: str
     """Dataset the log belongs to."""
 
@@ -163,7 +166,11 @@ class LazySceneSequence(Sequence[SceneAPI]):
         log_position = int(np.searchsorted(self._log_starts, flat_index, side="right")) - 1
         log_index = self._log_indices[log_position]
         anchor_index = int(log_index.anchor_indices[flat_index - self._log_starts[log_position]])
-        return ArrowSceneAPI(log_dir=log_index.log_dir, scene_metadata=log_index.scene_metadata_at(anchor_index))
+        return ArrowSceneAPI(
+            log_dir=log_index.log_dir,
+            scene_metadata=log_index.scene_metadata_at(anchor_index),
+            maps_root=log_index.maps_root,
+        )
 
     def anchor_columns(self) -> Tuple[List[str], np.ndarray, np.ndarray]:
         """Identify every scene by its log and initial timestamp, building none of them.
@@ -295,6 +302,7 @@ def build_log_scene_index(
     log_dir: Path,
     filter: SceneFilter,
     target_uuids_binary: Optional[pa.Array] = None,
+    maps_root: Optional[Path] = None,
 ) -> Optional[LogSceneIndex]:
     """Index one log's scenes without building a scene object.
 
@@ -364,6 +372,7 @@ def build_log_scene_index(
         timestamps_us = np.asarray(sync_table["sync.timestamp_us"].to_numpy(), dtype=np.int64)
         return LogSceneIndex(
             log_dir=log_dir,
+            maps_root=maps_root,
             dataset=log_metadata.dataset,
             split=log_metadata.split,
             anchor_indices=anchors,

--- a/tests/unit/api/scene/arrow/test_arrow_scene_builder.py
+++ b/tests/unit/api/scene/arrow/test_arrow_scene_builder.py
@@ -9,6 +9,7 @@ import pytest
 
 from py123d.api.scene.arrow.arrow_scene_builder import (
     ArrowSceneBuilder,
+    LazyArrowSceneBuilder,
     _apply_post_filters,
     _discover_split_names,
     _extract_scenes_from_log_dir,
@@ -1300,3 +1301,90 @@ class TestArrowSceneBuilderGetScenes:
         )
         assert len(scenes) == 1
         assert scenes[0].scene_metadata.initial_idx == 3
+
+
+# --- Scene-scoped maps root ---
+
+
+class TestSceneScopedMapsRoot:
+    """Scenes resolve their map under the builder's maps_root before the global paths."""
+
+    def test_scene_carries_maps_root_through_pickle(self, tmp_path):
+        import pickle
+
+        _write_demo_log(tmp_path)
+        maps_root = tmp_path / "maps"
+        for builder_class in (ArrowSceneBuilder, LazyArrowSceneBuilder):
+            builder = builder_class(logs_root=tmp_path / "logs", maps_root=maps_root)
+            scenes = builder.get_scenes(SceneFilter(), SequentialExecutor())
+            assert len(scenes) > 0
+            scene = scenes[0]
+            assert scene._maps_root == maps_root
+            restored = pickle.loads(pickle.dumps(scene))
+            assert restored._maps_root == maps_root
+
+    def test_resolution_order(self, tmp_path, monkeypatch):
+        from py123d.api.map.arrow import arrow_map_api
+        from py123d.common.runtime import DatasetPaths
+
+        log_dir = tmp_path / "logs" / "test-dataset_train" / "log_001"
+        log_dir.mkdir(parents=True)
+        log_metadata = _make_log_metadata()
+
+        builder_maps_root = tmp_path / "builder_maps"
+        global_maps_root = tmp_path / "global_maps"
+        for root in (builder_maps_root, global_maps_root):
+            (root / "test-dataset").mkdir(parents=True)
+            (root / "test-dataset" / "test-dataset_boston.arrow").touch()
+
+        monkeypatch.setattr(arrow_map_api, "get_lru_cached_map_api", lambda path: path)
+        monkeypatch.setattr(arrow_map_api, "get_dataset_paths", lambda: DatasetPaths())
+
+        # No maps_root and no global paths: unresolved
+        assert arrow_map_api.get_map_api_for_log(log_dir, log_metadata) is None
+        # The given maps_root resolves without global paths
+        assert (
+            arrow_map_api.get_map_api_for_log(log_dir, log_metadata, maps_root=builder_maps_root)
+            == builder_maps_root / "test-dataset" / "test-dataset_boston.arrow"
+        )
+
+        # The global paths remain the fallback
+        monkeypatch.setattr(
+            arrow_map_api,
+            "get_dataset_paths",
+            lambda: DatasetPaths(py123d_maps_root=global_maps_root),
+        )
+        assert (
+            arrow_map_api.get_map_api_for_log(log_dir, log_metadata)
+            == global_maps_root / "test-dataset" / "test-dataset_boston.arrow"
+        )
+        # The given maps_root wins over the global paths
+        assert (
+            arrow_map_api.get_map_api_for_log(log_dir, log_metadata, maps_root=builder_maps_root)
+            == builder_maps_root / "test-dataset" / "test-dataset_boston.arrow"
+        )
+        # A missing file under the given maps_root falls back to the global paths
+        (builder_maps_root / "test-dataset" / "test-dataset_boston.arrow").unlink()
+        assert (
+            arrow_map_api.get_map_api_for_log(log_dir, log_metadata, maps_root=builder_maps_root)
+            == global_maps_root / "test-dataset" / "test-dataset_boston.arrow"
+        )
+
+    def test_per_log_map_wins(self, tmp_path, monkeypatch):
+        from py123d.api.map.arrow import arrow_map_api
+        from py123d.common.runtime import DatasetPaths
+
+        log_dir = tmp_path / "log_001"
+        log_dir.mkdir(parents=True)
+        (log_dir / "map.arrow").touch()
+        maps_root = tmp_path / "maps"
+        (maps_root / "test-dataset").mkdir(parents=True)
+        (maps_root / "test-dataset" / "test-dataset_boston.arrow").touch()
+
+        monkeypatch.setattr(arrow_map_api, "get_lru_cached_map_api", lambda path: path)
+        monkeypatch.setattr(arrow_map_api, "get_dataset_paths", lambda: DatasetPaths())
+
+        assert (
+            arrow_map_api.get_map_api_for_log(log_dir, _make_log_metadata(), maps_root=maps_root)
+            == log_dir / "map.arrow"
+        )


### PR DESCRIPTION
This helps to make multi-dataset training more robust. 

Not sure if the right design. Basically PY123D_DATA_ROOT can be set to one single dataset but in training with multiple different datasets this can get in the way.